### PR TITLE
[BUGFIX] Remove BrowserAnimationsModule from MaterialModule

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,17 +1,9 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { ServiceFormComponent } from './offering/service/service-form/service-form.component';
-import { ServiceDetailsComponent } from './offering/service/service-details/service-details.component';
 import { HomeComponent } from './home/home.component';
-import { ListServicesComponent } from './offering/service/list-services/list-services.component';
-import { OfferingModule } from './offering/offering.module';
 
 const routes: Routes = [
-  { path: 'servicePage', component: ListServicesComponent },
-  {path : 'service/:id', component:ServiceDetailsComponent},
-  {path:'serviceEditForm/:id' , component:ServiceFormComponent},
-  {path :'serviceCreateForm', component: ServiceFormComponent},
   {
     path: '',
     component: HomeComponent,
@@ -20,11 +12,11 @@ const routes: Routes = [
     path: 'user',
     loadChildren: () => import('./user/user.module').then((m) => m.UserModule),
   },
-  /*{
+  {
     path: 'service',
-    loadChildren: () => import('./offering/service/service.module').then((m) => m.ServiceModule),
-  },*/
-
+    loadChildren: () =>
+      import('./offering/service/service.module').then((m) => m.ServiceModule),
+  },
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,11 +12,17 @@ import { LayoutModule } from './layout/layout.module';
 import { OfferingModule } from './offering/offering.module';
 
 @NgModule({
-  declarations:  [AppComponent, HomeComponent],
-  imports: [BrowserModule, AppRoutingModule, LayoutModule, MaterialModule,EventModule,
-    OfferingModule],
+  declarations: [AppComponent, HomeComponent],
+  imports: [
+    BrowserModule,
+    AppRoutingModule,
+    LayoutModule,
+    MaterialModule,
+    EventModule,
+    OfferingModule,
+  ],
 
-  providers: [provideAnimationsAsync(), provideToastr()], 
+  providers: [provideAnimationsAsync(), provideToastr()],
 
   bootstrap: [AppComponent],
 })

--- a/src/app/infrastructure/material/material.module.ts
+++ b/src/app/infrastructure/material/material.module.ts
@@ -1,7 +1,7 @@
 import { DialogModule } from '@angular/cdk/dialog';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -21,9 +21,6 @@ import { MatSlider, MatSliderModule } from '@angular/material/slider';
 import { MatStepperModule } from '@angular/material/stepper';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-
-
 
 const components = [
   CommonModule,
@@ -48,13 +45,10 @@ const components = [
   MatSlideToggle,
   MatAutocompleteModule,
   MatStepperModule,
-  ReactiveFormsModule,
-  BrowserAnimationsModule,
   MatDialogModule,
   DialogModule,
   MatDialogContent,
   MatTabsModule,
-
 ];
 
 @NgModule({

--- a/src/app/offering/service/service.module.ts
+++ b/src/app/offering/service/service.module.ts
@@ -1,15 +1,14 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 import { MaterialModule } from '../../infrastructure/material/material.module';
 import { ListServicesComponent } from './list-services/list-services.component';
-import { ServiceFormComponent } from './service-form/service-form.component';
-import { ServiceDialogComponent } from './service-dialog/service-dialog.component';
-import { ServiceDialogInformationComponent } from './service-dialog/service-dialog-information.component';
 import { ServiceCardComponent } from './service-card/service-card.component';
 import { ServiceDetailsComponent } from './service-details/service-details.component';
+import { ServiceDialogInformationComponent } from './service-dialog/service-dialog-information.component';
+import { ServiceDialogComponent } from './service-dialog/service-dialog.component';
+import { ServiceFormComponent } from './service-form/service-form.component';
 import { ServiceRoutingModule } from './service-routing.module';
-
-
 
 @NgModule({
   declarations: [
@@ -18,12 +17,13 @@ import { ServiceRoutingModule } from './service-routing.module';
     ServiceDialogComponent,
     ServiceDialogInformationComponent,
     ServiceCardComponent,
-    ServiceDetailsComponent
+    ServiceDetailsComponent,
   ],
   imports: [
     MaterialModule,
     CommonModule,
-    ServiceRoutingModule
-  ]
+    ServiceRoutingModule,
+    ReactiveFormsModule,
+  ],
 })
-export class ServiceModule { }
+export class ServiceModule {}


### PR DESCRIPTION
[BUGFIX] Remove BrowserAnimationsModule and ReactiveForms from MaterialModule.

BrowserAnimationsModule should only be imported once inside the app.

ReactiveFormsModule is not a Material module.