### PR TITLE
[REFACTOR] Event page actions and Privacy indicator

### DIFF
--- a/src/app/event/event-page/event-page.component.html
+++ b/src/app/event/event-page/event-page.component.html
@@ -4,8 +4,17 @@
       <div class="header-content">
         <div class="title-section">
           <mat-card-title class="event-title">{{ event.name }}</mat-card-title>
-          <mat-card-subtitle *ngIf="!!event.eventType" class="event-type">{{ event.eventType.name }}
-          </mat-card-subtitle>
+          <div class="event-subtitle">
+            <mat-card-subtitle *ngIf="!!event.eventType" class="event-type">
+              {{ event.eventType.name }}
+            </mat-card-subtitle>
+            <mat-chip [color]="event.privacyType === 'PRIVATE' ? 'warn' : 'primary'" class="privacy-chip">
+              <span class="wrapper">
+                <mat-icon class="privacy-icon">{{ event.privacyType === 'PRIVATE' ? 'lock' : 'public' }}</mat-icon>
+                <span>{{ event.privacyType | titlecase }}</span>
+              </span>
+            </mat-chip>
+          </div>
         </div>
         <button mat-icon-button color="warn" class="favorite-button" (click)="toggleFavorite()"
                 [matTooltip]="event.isFavorite ? 'Remove from favorites' : 'Add to favorites'">
@@ -22,7 +31,7 @@
           <mat-icon>edit</mat-icon>
           Edit Agenda
         </button>
-        <button mat-raised-button class="primary" (click)="openEmailDialog()">
+        <button mat-raised-button class="primary" (click)="openEmailDialog()" *ngIf="event.privacyType == 'PRIVATE'">
           <mat-icon>person_add</mat-icon>
           Invite People
         </button>
@@ -49,6 +58,28 @@
           <mat-icon>description</mat-icon>
           Save as PDF
         </a>
+      </mat-card-actions>
+
+      <mat-card-actions *ngIf="(isAttending$ | async) && !(isOrganizer$ | async)">
+        <a
+          mat-raised-button
+          class="primary"
+          [routerLink]="['/chat', event.organizer.id, event.organizer.name]"
+        >
+          <mat-icon>messages</mat-icon>
+          Chat with organizer
+        </a>
+      </mat-card-actions>
+
+      <mat-card-actions *ngIf="event.privacyType == 'PUBLIC' && !(isAttending$ | async) && !(isOrganizer$ | async)">
+        <button
+          mat-raised-button
+          class="primary"
+          (click)="joinEvent()"
+        >
+          <mat-icon>event</mat-icon>
+          Join Event!
+        </button>
       </mat-card-actions>
     </mat-card>
 
@@ -107,7 +138,7 @@
                 Agenda
               </mat-panel-title>
             </mat-expansion-panel-header>
-            <app-event-agenda [eventId]="eventId"/>
+            <app-event-agenda [eventId$]="eventId$"/>
           </mat-expansion-panel>
 
           <mat-expansion-panel>
@@ -131,7 +162,7 @@
             Agenda
           </mat-card-title>
           <mat-card-content>
-            <app-event-agenda [eventId]="eventId"/>
+            <app-event-agenda [eventId$]="eventId$"/>
           </mat-card-content>
         </mat-card>
       </div>

--- a/src/app/event/event-page/event-page.component.scss
+++ b/src/app/event/event-page/event-page.component.scss
@@ -183,6 +183,33 @@
   }
 }
 
+.event-subtitle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  .event-type {
+    margin: 0;
+  }
+
+  .privacy-chip {
+    height: 24px;
+    font-size: 0.9rem;
+
+    .wrapper {
+      display: flex;
+      align-items: center;
+    }
+
+    .privacy-icon {
+      font-size: 16px;
+      height: 16px;
+      width: 16px;
+      margin-right: 4px;
+    }
+  }
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/src/app/event/service/event.service.ts
+++ b/src/app/event/service/event.service.ts
@@ -252,6 +252,23 @@ export class EventService {
       .pipe(catchError(this.handleError));
   }
 
+  isAttending(eventId: number, userId: number): Observable<boolean> {
+    return this.httpClient
+      .get<boolean>(
+        environment.apiHost + `/api/events/${eventId}/attending/${userId}`,
+      )
+      .pipe(catchError(this.handleError));
+  }
+
+  joinEvent(eventId: number): Observable<HomeEvent> {
+    const userId = this.authService.getUser()?.userId;
+    return this.httpClient
+      .post<HomeEvent>(environment.apiHost + `/api/events/${eventId}/join`, {
+        userId,
+      })
+      .pipe(catchError(this.handleError));
+  }
+
   private handleError(error: HttpErrorResponse): Observable<never> {
     let errorResponse: ErrorResponse | null = null;
 

--- a/src/app/infrastructure/material/material.module.ts
+++ b/src/app/infrastructure/material/material.module.ts
@@ -7,6 +7,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckbox } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatNativeDateModule, MatOptionModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatDialogContent, MatDialogModule } from '@angular/material/dialog';
@@ -69,6 +70,7 @@ const components = [
   MatTooltip,
   MatExpansionModule,
   MatPaginator,
+  MatChipsModule,
 ];
 
 @NgModule({


### PR DESCRIPTION
Added public/private chip to event details page.

Made event actions that are shown consistent with event state and user role:
- Invite button is now only shown for private events,
- Attendees can see 'chat with organizer' button (except if the attendee is the organizer himself),
- Join button is visible on a public event page to a user that has not already joined.

Added the join event service methods.